### PR TITLE
let OAR take into account the memory parameter

### DIFF
--- a/dask_jobqueue/jobqueue.yaml
+++ b/dask_jobqueue/jobqueue.yaml
@@ -26,7 +26,8 @@ jobqueue:
     job-extra-directives: []
     job-directives-skip: []
     log-directory: null
-    
+    oar-mem-core-property-name: null
+
     # Scheduler options
     scheduler-options: {}
 
@@ -57,7 +58,7 @@ jobqueue:
     job-extra-directives: []
     job-directives-skip: []
     log-directory: null
-    
+
     # Scheduler options
     scheduler-options: {}
 
@@ -88,7 +89,7 @@ jobqueue:
     job-directives-skip: []
     log-directory: null
     resource-spec: null
-    
+
     # Scheduler options
     scheduler-options: {}
 
@@ -120,7 +121,7 @@ jobqueue:
     job-extra-directives: []
     job-directives-skip: []
     log-directory: null
-    
+
     # Scheduler options
     scheduler-options: {}
 
@@ -151,7 +152,7 @@ jobqueue:
     job-extra-directives: []
     job-directives-skip: []
     log-directory: null
-    
+
     # Scheduler options
     scheduler-options: {}
 
@@ -185,7 +186,7 @@ jobqueue:
     log-directory: null
     lsf-units: null
     use-stdin: True             # (bool) How jobs are launched, i.e. 'bsub jobscript.sh' or 'bsub < jobscript.sh'
-    
+
     # Scheduler options
     scheduler-options: {}
 
@@ -215,7 +216,7 @@ jobqueue:
     cancel-command-extra: []    # Extra condor_rm arguments
     log-directory: null
     shebang: "#!/usr/bin/env condor_submit"
-    
+
     # Scheduler options
     scheduler-options: {}
 
@@ -239,6 +240,6 @@ jobqueue:
     job-extra-directives: []
     job-directives-skip: []
     log-directory: null
-    
+
     # Scheduler options
     scheduler-options: {}

--- a/dask_jobqueue/oar.py
+++ b/dask_jobqueue/oar.py
@@ -1,5 +1,8 @@
 import logging
 import shlex
+import warnings
+
+from dask.utils import parse_bytes
 
 import dask
 
@@ -24,6 +27,7 @@ class OARJob(Job):
         project=None,
         resource_spec=None,
         walltime=None,
+        oar_mem_core_property_name=None,
         config_name=None,
         **base_class_kwargs
     ):
@@ -76,6 +80,42 @@ class OARJob(Job):
         # Add extra header directives
         header_lines.extend(["#OAR %s" % arg for arg in self.job_extra_directives])
 
+        # Memory
+        memory = self.worker_memory
+        if memory is not None:
+            if oar_mem_core_property_name is None:
+                oar_mem_core_property_name = dask.config.get(
+                    "jobqueue.%s.oar-mem-core-property-name" % self.config_name
+                )
+            if oar_mem_core_property_name is None:
+                warn = (
+                    "The OAR property name corresponding to the memory per core of your cluster has not been set. "
+                    "Thus, the memory parameter will not be used by OAR. "
+                    "It can be set through oar_mem_core_property_name, e.g., memcore, mem_core.. "
+                )
+                warnings.warn(warn, category=UserWarning)
+            else:
+                # OAR expects MiB as memory unit
+                oar_memory = int(
+                    parse_bytes(self.worker_memory / self.worker_cores) / 2**20
+                )
+                header_lines.append(
+                    "#OAR -p " + oar_mem_core_property_name + ">=%s" % oar_memory
+                )
+                # OAR needs to have the properties on a single line, with SQL syntaxe
+                # If there are several "#OAR -p" lines, only the last one will be taken into account by OAR
+                last_job_property = return_last_job_property(self.job_extra_directives)
+                if last_job_property is not None:
+                    header_lines.append(
+                        "#OAR -p "
+                        + '"'
+                        + last_job_property
+                        + " AND "
+                        + oar_mem_core_property_name
+                        + ">=%s" % oar_memory
+                        + '"'
+                    )
+
         self.job_header = "\n".join(header_lines)
 
         logger.debug("Job script: \n %s" % self.job_script())
@@ -123,6 +163,8 @@ class OARCluster(JobQueueCluster):
         Deprecated: use ``job_extra_directives`` instead. This parameter will be removed in a future version.
     job_extra_directives : list
         List of other OAR options, for example `-t besteffort`. Each option will be prepended with the #OAR prefix.
+    oar_mem_core_property_name : str
+        The memory per core property name of your OAR cluster, e.g., memcore, mem_core.. If None, warning to users.
 
     Examples
     --------
@@ -140,3 +182,13 @@ class OARCluster(JobQueueCluster):
         job=job_parameters, cluster=cluster_parameters
     )
     job_cls = OARJob
+
+
+def return_last_job_property(job_extra_directives):
+    job_properties = [
+        directive for directive in job_extra_directives if directive.startswith("-p")
+    ]
+    if job_properties:
+        return job_properties[-1].replace("-p ", "")
+    else:
+        return None

--- a/dask_jobqueue/oar.py
+++ b/dask_jobqueue/oar.py
@@ -164,7 +164,10 @@ class OARCluster(JobQueueCluster):
     job_extra_directives : list
         List of other OAR options, for example `-t besteffort`. Each option will be prepended with the #OAR prefix.
     oar_mem_core_property_name : str
-        The memory per core property name of your OAR cluster, e.g., memcore, mem_core.. If None, warning to users.
+        The memory per core property name of your OAR cluster (usually named `memcore` or `mem_core`).
+        Existing properties can be listed by `oarnodes` command.
+        Note that the memory per core property might not exist on your cluster.
+        If it is None, you will be warned that the memory parameter will not be taken into account by OAR.
 
     Examples
     --------

--- a/dask_jobqueue/tests/test_job.py
+++ b/dask_jobqueue/tests/test_job.py
@@ -147,30 +147,47 @@ def test_deprecation_header_skip(Cluster):
 
     job_cls = Cluster.job_cls
     with warnings.catch_warnings(record=True) as w:
-        # should give a warning
         job = job_cls(cores=1, memory="1 GB", header_skip=["old_param"])
-        assert len(w) == 1
+        # should give a FutureWarning about the deprecation of header_skip
         assert issubclass(w[0].category, FutureWarning)
         assert "header_skip has been renamed" in str(w[0].message)
+        if not isinstance(Cluster, "OARCluster"):
+            assert len(w) == 1
+        else:
+            # For OAR instance, should give a UserWarning when memcore property name is none
+            assert len(w) == 2
+            assert issubclass(w[1].category, UserWarning)
+            assert "the memory per core of your cluster has not been set" in str(
+                w[1].message
+            )
     with warnings.catch_warnings(record=True) as w:
-        # should give a warning
         job = job_cls(
             cores=1,
             memory="1 GB",
             header_skip=["old_param"],
             job_directives_skip=["new_param"],
         )
-        assert len(w) == 1
+        # should give a FutureWarning about the deprecation of header_skip
         assert issubclass(w[0].category, FutureWarning)
         assert "header_skip has been renamed" in str(w[0].message)
+        if not isinstance(Cluster, "OARCluster"):
+            assert len(w) == 1
+        else:
+            # For OAR instance, should give a UserWarning when memcore property name is none
+            assert len(w) == 2
+            assert issubclass(w[1].category, UserWarning)
+            assert "the memory per core of your cluster has not been set" in str(
+                w[1].message
+            )
     with warnings.catch_warnings(record=True) as w:
-        # should not give a warning
+        # should not give a FutureWarning
         job = job_cls(
             cores=1,
             memory="1 GB",
             job_directives_skip=["new_param"],
         )
-        assert len(w) == 0
+        if not isinstance(Cluster, "OARCluster"):
+            assert len(w) == 0
 
     # the rest is not about the warning but about behaviour: if job_directives_skip is not
     # set, header_skip should still be used if provided
@@ -240,8 +257,9 @@ def test_docstring_cluster(Cluster):
 def test_deprecation_env_extra(Cluster):
     import warnings
 
-    # test issuing of warning
-    warnings.simplefilter("always")
+    # test issuing of warning but ignore UserWarning
+    # for details about UserWarning of OARCluster, please see test_deprecation_header_skip()
+    warnings.simplefilter("ignore", UserWarning)
 
     job_cls = Cluster.job_cls
     with warnings.catch_warnings(record=True) as w:
@@ -304,8 +322,9 @@ def test_deprecation_env_extra(Cluster):
 def test_deprecation_extra(Cluster):
     import warnings
 
-    # test issuing of warning
-    warnings.simplefilter("always")
+    # test issuing of warning but ignore UserWarning
+    # for details about UserWarning of OARCluster, please see test_deprecation_header_skip()
+    warnings.simplefilter("ignore", UserWarning)
 
     job_cls = Cluster.job_cls
     with warnings.catch_warnings(record=True) as w:
@@ -371,8 +390,9 @@ def test_deprecation_job_extra(Cluster):
 
     import warnings
 
-    # test issuing of warning
-    warnings.simplefilter("always")
+    # test issuing of warning but ignore UserWarning
+    # for details about UserWarning of OARCluster, please see test_deprecation_header_skip()
+    warnings.simplefilter("ignore", UserWarning)
 
     job_cls = Cluster.job_cls
     with warnings.catch_warnings(record=True) as w:

--- a/dask_jobqueue/tests/test_job.py
+++ b/dask_jobqueue/tests/test_job.py
@@ -204,6 +204,7 @@ def test_deprecation_header_skip(Cluster):
     job_script = job.job_script()
     assert "jobname" not in job_script
 
+
 @pytest.mark.asyncio
 async def test_nworkers_scale():
     async with LocalCluster(

--- a/dask_jobqueue/tests/test_job.py
+++ b/dask_jobqueue/tests/test_job.py
@@ -138,7 +138,7 @@ def test_header_lines_dont_skip_extra_directives():
 # Test only header_skip for the cluster implementation that uses job_name.
 
 
-@pytest.mark.parametrize("Cluster", [PBSCluster, SLURMCluster, SGECluster, OARCluster])
+@pytest.mark.parametrize("Cluster", [PBSCluster, SLURMCluster, SGECluster])
 def test_deprecation_header_skip(Cluster):
     import warnings
 
@@ -147,47 +147,110 @@ def test_deprecation_header_skip(Cluster):
 
     job_cls = Cluster.job_cls
     with warnings.catch_warnings(record=True) as w:
+        # should give a warning
         job = job_cls(cores=1, memory="1 GB", header_skip=["old_param"])
-        # should give a FutureWarning about the deprecation of header_skip
+        assert len(w) == 1
         assert issubclass(w[0].category, FutureWarning)
         assert "header_skip has been renamed" in str(w[0].message)
-        if not isinstance(Cluster, "OARCluster"):
-            assert len(w) == 1
-        else:
-            # For OAR instance, should give a UserWarning when memcore property name is none
-            assert len(w) == 2
-            assert issubclass(w[1].category, UserWarning)
-            assert "the memory per core of your cluster has not been set" in str(
-                w[1].message
-            )
     with warnings.catch_warnings(record=True) as w:
+        # should give a warning
         job = job_cls(
             cores=1,
             memory="1 GB",
             header_skip=["old_param"],
             job_directives_skip=["new_param"],
         )
-        # should give a FutureWarning about the deprecation of header_skip
+        assert len(w) == 1
         assert issubclass(w[0].category, FutureWarning)
         assert "header_skip has been renamed" in str(w[0].message)
-        if not isinstance(Cluster, "OARCluster"):
-            assert len(w) == 1
-        else:
-            # For OAR instance, should give a UserWarning when memcore property name is none
-            assert len(w) == 2
-            assert issubclass(w[1].category, UserWarning)
-            assert "the memory per core of your cluster has not been set" in str(
-                w[1].message
-            )
     with warnings.catch_warnings(record=True) as w:
-        # should not give a FutureWarning
+        # should not give a warning
         job = job_cls(
             cores=1,
             memory="1 GB",
             job_directives_skip=["new_param"],
         )
-        if not isinstance(Cluster, "OARCluster"):
-            assert len(w) == 0
+        assert len(w) == 0
+
+    # the rest is not about the warning but about behaviour: if job_directives_skip is not
+    # set, header_skip should still be used if provided
+    warnings.simplefilter("ignore")
+    job = job_cls(
+        cores=1,
+        memory="1 GB",
+        job_name="jobname",
+        header_skip=["jobname"],
+        job_directives_skip=["new_param"],
+    )
+    job_script = job.job_script()
+    assert "jobname" in job_script
+
+    job = job_cls(
+        cores=1,
+        memory="1 GB",
+        job_name="jobname",
+        header_skip=["jobname"],
+    )
+    job_script = job.job_script()
+    assert "jobname" not in job_script
+
+    job = job_cls(
+        cores=1,
+        memory="1 GB",
+        job_name="jobname",
+        header_skip=["jobname"],
+        job_directives_skip=(),
+    )
+    job_script = job.job_script()
+    assert "jobname" not in job_script
+
+
+def test_deprecation_header_skip_OARCluster():
+    import warnings
+
+    # test issuing of warning
+    warnings.simplefilter("always")
+
+    job_cls = OARCluster.job_cls
+    with warnings.catch_warnings(record=True) as w:
+        # should give a FutureWarning about the deprecation of head_skip
+        # and a UserWarning when the memcore property name is None
+        job = job_cls(cores=1, memory="1 GB", header_skip=["old_param"])
+        assert len(w) == 2
+        assert issubclass(w[0].category, FutureWarning)
+        assert "header_skip has been renamed" in str(w[0].message)
+        assert issubclass(w[1].category, UserWarning)
+        assert "the memory per core of your cluster has not been set" in str(
+            w[1].message
+        )
+    with warnings.catch_warnings(record=True) as w:
+        # should give a FutureWarning about the deprecation of head_skip
+        # and a UserWarning when the memcore property name is None
+        job = job_cls(
+            cores=1,
+            memory="1 GB",
+            header_skip=["old_param"],
+            job_directives_skip=["new_param"],
+        )
+        assert len(w) == 2
+        assert issubclass(w[0].category, FutureWarning)
+        assert "header_skip has been renamed" in str(w[0].message)
+        assert issubclass(w[1].category, UserWarning)
+        assert "the memory per core of your cluster has not been set" in str(
+            w[1].message
+        )
+    with warnings.catch_warnings(record=True) as w:
+        # should only give a UserWarning
+        job = job_cls(
+            cores=1,
+            memory="1 GB",
+            job_directives_skip=["new_param"],
+        )
+        assert len(w) == 1
+        assert issubclass(w[0].category, UserWarning)
+        assert "the memory per core of your cluster has not been set" in str(
+            w[0].message
+        )
 
     # the rest is not about the warning but about behaviour: if job_directives_skip is not
     # set, header_skip should still be used if provided
@@ -258,7 +321,7 @@ def test_deprecation_env_extra(Cluster):
     import warnings
 
     # test issuing of warning but ignore UserWarning
-    # for details about UserWarning of OARCluster, please see test_deprecation_header_skip()
+    # for details about UserWarning of OARCluster, please see test_deprecation_header_skip_OARCluster()
     warnings.simplefilter("ignore", UserWarning)
 
     job_cls = Cluster.job_cls
@@ -323,7 +386,7 @@ def test_deprecation_extra(Cluster):
     import warnings
 
     # test issuing of warning but ignore UserWarning
-    # for details about UserWarning of OARCluster, please see test_deprecation_header_skip()
+    # for details about UserWarning of OARCluster, please see test_deprecation_header_skip_OARCluster()
     warnings.simplefilter("ignore", UserWarning)
 
     job_cls = Cluster.job_cls
@@ -391,7 +454,7 @@ def test_deprecation_job_extra(Cluster):
     import warnings
 
     # test issuing of warning but ignore UserWarning
-    # for details about UserWarning of OARCluster, please see test_deprecation_header_skip()
+    # for details about UserWarning of OARCluster, please see test_deprecation_header_skip_OARCluster()
     warnings.simplefilter("ignore", UserWarning)
 
     job_cls = Cluster.job_cls

--- a/dask_jobqueue/tests/test_job.py
+++ b/dask_jobqueue/tests/test_job.py
@@ -138,12 +138,12 @@ def test_header_lines_dont_skip_extra_directives():
 # Test only header_skip for the cluster implementation that uses job_name.
 
 
-@pytest.mark.parametrize("Cluster", [PBSCluster, SLURMCluster, SGECluster])
+@pytest.mark.parametrize("Cluster", [PBSCluster, SLURMCluster, SGECluster, OARCluster])
 def test_deprecation_header_skip(Cluster):
     import warnings
 
-    # test issuing of warning
-    warnings.simplefilter("always")
+    # test issuing of warning but ignore UserWarning
+    warnings.simplefilter("ignore", UserWarning)
 
     job_cls = Cluster.job_cls
     with warnings.catch_warnings(record=True) as w:
@@ -204,87 +204,6 @@ def test_deprecation_header_skip(Cluster):
     job_script = job.job_script()
     assert "jobname" not in job_script
 
-
-def test_deprecation_header_skip_OARCluster():
-    import warnings
-
-    # test issuing of warning
-    warnings.simplefilter("always")
-
-    job_cls = OARCluster.job_cls
-    with warnings.catch_warnings(record=True) as w:
-        # should give a FutureWarning about the deprecation of head_skip
-        # and a UserWarning when the memcore property name is None
-        job = job_cls(cores=1, memory="1 GB", header_skip=["old_param"])
-        assert len(w) == 2
-        assert issubclass(w[0].category, FutureWarning)
-        assert "header_skip has been renamed" in str(w[0].message)
-        assert issubclass(w[1].category, UserWarning)
-        assert "the memory per core of your cluster has not been set" in str(
-            w[1].message
-        )
-    with warnings.catch_warnings(record=True) as w:
-        # should give a FutureWarning about the deprecation of head_skip
-        # and a UserWarning when the memcore property name is None
-        job = job_cls(
-            cores=1,
-            memory="1 GB",
-            header_skip=["old_param"],
-            job_directives_skip=["new_param"],
-        )
-        assert len(w) == 2
-        assert issubclass(w[0].category, FutureWarning)
-        assert "header_skip has been renamed" in str(w[0].message)
-        assert issubclass(w[1].category, UserWarning)
-        assert "the memory per core of your cluster has not been set" in str(
-            w[1].message
-        )
-    with warnings.catch_warnings(record=True) as w:
-        # should only give a UserWarning
-        job = job_cls(
-            cores=1,
-            memory="1 GB",
-            job_directives_skip=["new_param"],
-        )
-        assert len(w) == 1
-        assert issubclass(w[0].category, UserWarning)
-        assert "the memory per core of your cluster has not been set" in str(
-            w[0].message
-        )
-
-    # the rest is not about the warning but about behaviour: if job_directives_skip is not
-    # set, header_skip should still be used if provided
-    warnings.simplefilter("ignore")
-    job = job_cls(
-        cores=1,
-        memory="1 GB",
-        job_name="jobname",
-        header_skip=["jobname"],
-        job_directives_skip=["new_param"],
-    )
-    job_script = job.job_script()
-    assert "jobname" in job_script
-
-    job = job_cls(
-        cores=1,
-        memory="1 GB",
-        job_name="jobname",
-        header_skip=["jobname"],
-    )
-    job_script = job.job_script()
-    assert "jobname" not in job_script
-
-    job = job_cls(
-        cores=1,
-        memory="1 GB",
-        job_name="jobname",
-        header_skip=["jobname"],
-        job_directives_skip=(),
-    )
-    job_script = job.job_script()
-    assert "jobname" not in job_script
-
-
 @pytest.mark.asyncio
 async def test_nworkers_scale():
     async with LocalCluster(
@@ -321,7 +240,6 @@ def test_deprecation_env_extra(Cluster):
     import warnings
 
     # test issuing of warning but ignore UserWarning
-    # for details about UserWarning of OARCluster, please see test_deprecation_header_skip_OARCluster()
     warnings.simplefilter("ignore", UserWarning)
 
     job_cls = Cluster.job_cls
@@ -386,7 +304,6 @@ def test_deprecation_extra(Cluster):
     import warnings
 
     # test issuing of warning but ignore UserWarning
-    # for details about UserWarning of OARCluster, please see test_deprecation_header_skip_OARCluster()
     warnings.simplefilter("ignore", UserWarning)
 
     job_cls = Cluster.job_cls
@@ -454,7 +371,6 @@ def test_deprecation_job_extra(Cluster):
     import warnings
 
     # test issuing of warning but ignore UserWarning
-    # for details about UserWarning of OARCluster, please see test_deprecation_header_skip_OARCluster()
     warnings.simplefilter("ignore", UserWarning)
 
     job_cls = Cluster.job_cls

--- a/dask_jobqueue/tests/test_oar.py
+++ b/dask_jobqueue/tests/test_oar.py
@@ -12,11 +12,9 @@ def test_header():
         processes=4,
         cores=8,
         memory="28GB",
-        oar_mem_core_property_name="memcore",
     ) as cluster:
         assert "#OAR -n dask-worker" in cluster.job_header
         assert "#OAR -l /nodes=1/core=8,walltime=00:02:00" in cluster.job_header
-        assert "#OAR -p memcore>=3337" in cluster.job_header
         assert "#OAR --project" not in cluster.job_header
         assert "#OAR -q" not in cluster.job_header
 
@@ -26,14 +24,12 @@ def test_header():
         processes=4,
         cores=8,
         memory="28GB",
-        oar_mem_core_property_name="mem_core",
         job_extra_directives=["-t besteffort"],
     ) as cluster:
         assert "walltime=" in cluster.job_header
         assert "#OAR --project DaskOnOar" in cluster.job_header
         assert "#OAR -q regular" in cluster.job_header
         assert "#OAR -t besteffort" in cluster.job_header
-        assert "#OAR -p mem_core>=3337" in cluster.job_header
 
     with OARCluster(
         cores=4, memory="8GB", oar_mem_core_property_name="memcore"
@@ -54,16 +50,6 @@ def test_header():
         assert "#OAR -n dask-worker" in cluster.job_header
         assert "#OAR -l /nodes=1/core=8,walltime=00:02:00" in cluster.job_header
         assert "#OAR -p mem_core>=3337" in cluster.job_header
-
-    with OARCluster(
-        cores=8,
-        memory="28GB",
-        job_extra_directives=["-p cluster='yeti'"],
-        oar_mem_core_property_name="memcore",
-    ) as cluster:
-        assert "#OAR -n dask-worker" in cluster.job_header
-        assert "#OAR -l /nodes=1/core=8" in cluster.job_header
-        assert "#OAR -p \"cluster='yeti' AND memcore>=3337\"" in cluster.job_header
 
     with OARCluster(
         cores=4,
@@ -185,7 +171,7 @@ def test_oar_mem_core_property_name_none_warning():
         assert len(w) == 1
         assert issubclass(w[0].category, UserWarning)
         assert (
-            "The OAR property name corresponding to the memory per core of your cluster has not been set"
+            "oar_mem_core_property_name is not set"
             in str(w[0].message)
         )
         job_script = job.job_script()

--- a/dask_jobqueue/tests/test_oar.py
+++ b/dask_jobqueue/tests/test_oar.py
@@ -8,10 +8,7 @@ from dask_jobqueue import OARCluster
 
 def test_header():
     with OARCluster(
-        walltime="00:02:00",
-        processes=4,
-        cores=8,
-        memory="28GB",
+        walltime="00:02:00", processes=4, cores=8, memory="28GB"
     ) as cluster:
         assert "#OAR -n dask-worker" in cluster.job_header
         assert "#OAR -l /nodes=1/core=8,walltime=00:02:00" in cluster.job_header

--- a/dask_jobqueue/tests/test_oar.py
+++ b/dask_jobqueue/tests/test_oar.py
@@ -14,6 +14,7 @@ def test_header():
         assert "#OAR -l /nodes=1/core=8,walltime=00:02:00" in cluster.job_header
         assert "#OAR --project" not in cluster.job_header
         assert "#OAR -q" not in cluster.job_header
+        assert "#OAR -p" not in cluster.job_header
 
     with OARCluster(
         queue="regular",
@@ -34,6 +35,37 @@ def test_header():
         assert "#OAR --project" not in cluster.job_header
         assert "#OAR -q" not in cluster.job_header
 
+    with OARCluster(
+        walltime="00:02:00",
+        processes=4,
+        cores=8,
+        memory="28GB",
+        oar_mem_core_property_name="memcore",
+    ) as cluster:
+        assert "#OAR -n dask-worker" in cluster.job_header
+        assert "#OAR -l /nodes=1/core=8,walltime=00:02:00" in cluster.job_header
+        assert "#OAR -p memcore>=3337" in cluster.job_header
+
+    with OARCluster(
+        cores=8,
+        memory="28GB",
+        job_extra_directives=["-p cluster='yeti'"],
+        oar_mem_core_property_name="mem_core",
+    ) as cluster:
+        assert "#OAR -n dask-worker" in cluster.job_header
+        assert "#OAR -l /nodes=1/core=8" in cluster.job_header
+        assert "#OAR -p \"cluster='yeti' AND mem_core>=3337\"" in cluster.job_header
+
+    with OARCluster(
+        cores=4,
+        memory="28MB",
+        job_extra_directives=["-p gpu_count=1"],
+        oar_mem_core_property_name="mem_core",
+    ) as cluster:
+        assert "#OAR -n dask-worker" in cluster.job_header
+        assert "walltime=" in cluster.job_header
+        assert '#OAR -p "gpu_count=1 AND mem_core>=6"' in cluster.job_header
+
 
 def test_job_script():
     with OARCluster(
@@ -47,6 +79,7 @@ def test_job_script():
         assert "#OAR -l /nodes=1/core=8,walltime=00:02:00" in job_script
         assert "#OAR --project" not in job_script
         assert "#OAR -q" not in job_script
+        assert "#OAR -p" not in job_script
 
         assert "export " not in job_script
 
@@ -64,6 +97,7 @@ def test_job_script():
         processes=4,
         cores=8,
         memory="28GB",
+        oar_mem_core_property_name="memcore",
         job_script_prologue=[
             'export LANG="en_US.utf8"',
             'export LANGUAGE="en_US.utf8"',
@@ -76,6 +110,7 @@ def test_job_script():
         formatted_bytes = format_bytes(parse_bytes("7GB")).replace(" ", "")
         assert f"--memory-limit {formatted_bytes}" in job_script
         assert "#OAR -l /nodes=1/core=8,walltime=00:02:00" in job_script
+        assert "#OAR -p memcore>=3337" in job_script
         assert "#OAR --project" not in job_script
         assert "#OAR -q" not in job_script
 
@@ -118,6 +153,7 @@ def test_config_name_oar_takes_custom_config():
         "job-cpu": None,
         "job-mem": None,
         "resource-spec": None,
+        "oar-mem-core-property-name": None,
     }
 
     with dask.config.set({"jobqueue.oar-config-name": conf}):

--- a/dask_jobqueue/tests/test_oar.py
+++ b/dask_jobqueue/tests/test_oar.py
@@ -167,10 +167,7 @@ def test_oar_mem_core_property_name_none_warning():
         job = job_cls(cores=1, memory="1 GB")
         assert len(w) == 1
         assert issubclass(w[0].category, UserWarning)
-        assert (
-            "oar_mem_core_property_name is not set"
-            in str(w[0].message)
-        )
+        assert "oar_mem_core_property_name is not set" in str(w[0].message)
         job_script = job.job_script()
         assert "#OAR -p" not in job_script
 

--- a/dask_jobqueue/tests/test_oar.py
+++ b/dask_jobqueue/tests/test_oar.py
@@ -188,6 +188,9 @@ def test_oar_mem_core_property_name_none_warning():
             "The OAR property name corresponding to the memory per core of your cluster has not been set"
             in str(w[0].message)
         )
+        job_script = job.job_script()
+        assert "#OAR -p" not in job_script
+
     with warnings.catch_warnings(record=True) as w:
         # should not give a warning
         job = job_cls(
@@ -196,3 +199,5 @@ def test_oar_mem_core_property_name_none_warning():
             oar_mem_core_property_name="memcore",
         )
         assert len(w) == 0
+        job_script = job.job_script()
+        assert "#OAR -p memcore" in job_script


### PR DESCRIPTION
During my experiments, it seems that OARCluster implementation does not let OAR take into account the memory parameter, as the SlurmCluster does. For example, if 256GB are asked for Dask workers as memory on a specific node, OAR is not aware about this memory request and thus place the job on one node without the specified memory capacity. To be sure that OAR takes into account the memory parameter as Slurm does, I propose this pull request.

This code is tested on Grid5000 and igrida (local OAR cluster of Inria Rennes). Since the memory per core property name may differ from one cluster to another, I introduced a parameter specifically for OAR: oar_mem_core_property_name to let users specify it for his own cluster. OAR can then manage the memory request with the “#OAR -p” line.